### PR TITLE
Ensure -lz is in `PKG_LIBS`

### DIFF
--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -9,7 +9,7 @@ USER_INCLUDE = ${R_PACKAGE_DIR}/include
 USER_LIB_DIR = ${R_PACKAGE_DIR}/lib${R_ARCH}/
 
 PKG_CFLAGS = -I${HDF5_INCLUDE} 
-PKG_LIBS = ${USER_LIB_DIR}libhdf5.a ${USER_LIB_DIR}libsz.a
+PKG_LIBS = ${USER_LIB_DIR}libhdf5.a ${USER_LIB_DIR}libsz.a -lz
 
 all: copying $(SHLIB)
 


### PR DESCRIPTION
When R is statically linked to zlib, the R linker flags do not include "-lz". Rhdf5lib assumes that "-lz" is always present, so it breaks in the static case. The fix is to add "-lz" explicitly to `PKG_LIBS`.