### PR TITLE
FreeBSD support

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -30,31 +30,22 @@ pkgconfig <- function(opt = c("PKG_CXX_LIBS", "PKG_C_LIBS")) {
                     # }, 
                      PKG_C_LIBS = {
                          switch(Sys.info()['sysname'], 
-                                Linux = {
-                                    sprintf('%s/libhdf5.a %s/libsz.a -lz',
-                                            patharch, patharch)
-                                }, Darwin = {
-                                    sprintf('%s/libhdf5.a %s/libsz.a -lz', 
-                                            patharch, patharch)
-                                }, Windows = {
+                                Windows = {
                                     patharch <- gsub(x = shortPathName(patharch),
                                                    pattern = "\\",
                                                    replacement = "/", 
                                                    fixed = TRUE)
                                     sprintf('-L%s -lhdf5 -lszip -lz -lpsapi', 
                                             patharch)
+                                }, {
+                                    sprintf('%s/libhdf5.a %s/libsz.a -lz', 
+                                            patharch, patharch)
                                 }
                          )
                      }, 
                      PKG_CXX_LIBS = {
                          switch(Sys.info()['sysname'], 
-                                Linux = {
-                                    sprintf('%s/libhdf5_cpp.a %s/libhdf5.a %s/libsz.a -lz',
-                                            patharch, patharch, patharch)
-                                }, Darwin = {
-                                    sprintf('%s/libhdf5_cpp.a %s/libhdf5.a %s/libsz.a -lz', 
-                                            patharch, patharch, patharch)
-                                }, Windows = {
+                                Windows = {
                                    ## for some reason double quotes aren't always sufficient
                                    ## so we use the 8+3 form of the path
                                    patharch <- gsub(x = shortPathName(patharch),
@@ -63,6 +54,9 @@ pkgconfig <- function(opt = c("PKG_CXX_LIBS", "PKG_C_LIBS")) {
                                                    fixed = TRUE)
                                     sprintf('-L%s -lhdf5_cpp -lhdf5 -lszip -lz -lpsapi', 
                                             patharch)
+                                }, {
+                                    sprintf('%s/libhdf5_cpp.a %s/libhdf5.a %s/libsz.a -lz',
+                                            patharch, patharch, patharch)
                                 }
                          )
                      }


### PR DESCRIPTION
pkgconfig currently returns nothing on FreeBSD. Linux, Darwin, FreeBSD, and probably other unix-like platforms all conveniently use the same config so they can be handled with a default condition in the switch.