### PR TITLE
Passing AR and RANLIB to configure for szip/hdf5

### DIFF
--- a/configure
+++ b/configure
@@ -2152,6 +2152,8 @@ CPPFLAGS=`"${R_HOME}/bin/R" CMD config CPPFLAGS`
 F77=`"${R_HOME}/bin/R" CMD config F77`
 MAKE=`"${R_HOME}/bin/R" CMD config MAKE`
 LDFLAGS=`"${R_HOME}/bin/R" CMD config LDFLAGS`
+AR=`"${R_HOME}/bin/R" CMD config AR`
+RANLIB=`"${R_HOME}/bin/R" CMD config RANLIB`//?/
 ac_ext=cpp
 ac_cpp='$CXXCPP $CPPFLAGS'
 ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
@@ -4247,7 +4249,8 @@ fi;
 echo "building the szip library...";
 cd ${BASEPBNAME}/szip;
 ./configure --with-pic --enable-shared=no \
-    CC="${CC}" CFLAGS="${CFLAGS} ${CPICFLAGS}" CPPFLAGS="${CPPFLAGS}"
+    CC="${CC}" CFLAGS="${CFLAGS} ${CPICFLAGS}" CPPFLAGS="${CPPFLAGS}" \
+    AR="${AR}" RANLIB="${RANLIB}
 $MAKE
 $MAKE install
 SZIP_HOME=`pwd -P`/szip
@@ -4260,7 +4263,8 @@ cd ../;
     ${WITH_S3_VFD} \
     CXX="${CXX}" CXXFLAGS="${CXXFLAGS} ${CXXPICFLAGS}" \
     CC="${CC}" CFLAGS="${CFLAGS} ${CPICFLAGS}" \
-    CPPFLAGS="${CPPFLAGS}" LDFLAGS="${LDFLAGS}"
+    CPPFLAGS="${CPPFLAGS}" LDFLAGS="${LDFLAGS}" \
+    AR="${AR}" RANLIB="${RANLIB}
 $MAKE lib
 #echo "Make return value: $?"
 if  test "$?" != 0 ; then :

--- a/configure
+++ b/configure
@@ -2152,8 +2152,6 @@ CPPFLAGS=`"${R_HOME}/bin/R" CMD config CPPFLAGS`
 F77=`"${R_HOME}/bin/R" CMD config F77`
 MAKE=`"${R_HOME}/bin/R" CMD config MAKE`
 LDFLAGS=`"${R_HOME}/bin/R" CMD config LDFLAGS`
-AR=`"${R_HOME}/bin/R" CMD config AR`
-RANLIB=`"${R_HOME}/bin/R" CMD config RANLIB`//?/
 ac_ext=cpp
 ac_cpp='$CXXCPP $CPPFLAGS'
 ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
@@ -4249,8 +4247,7 @@ fi;
 echo "building the szip library...";
 cd ${BASEPBNAME}/szip;
 ./configure --with-pic --enable-shared=no \
-    CC="${CC}" CFLAGS="${CFLAGS} ${CPICFLAGS}" CPPFLAGS="${CPPFLAGS}" \
-    AR="${AR}" RANLIB="${RANLIB}
+    CC="${CC}" CFLAGS="${CFLAGS} ${CPICFLAGS}" CPPFLAGS="${CPPFLAGS}"
 $MAKE
 $MAKE install
 SZIP_HOME=`pwd -P`/szip
@@ -4263,8 +4260,7 @@ cd ../;
     ${WITH_S3_VFD} \
     CXX="${CXX}" CXXFLAGS="${CXXFLAGS} ${CXXPICFLAGS}" \
     CC="${CC}" CFLAGS="${CFLAGS} ${CPICFLAGS}" \
-    CPPFLAGS="${CPPFLAGS}" LDFLAGS="${LDFLAGS}" \
-    AR="${AR}" RANLIB="${RANLIB}
+    CPPFLAGS="${CPPFLAGS}" LDFLAGS="${LDFLAGS}"
 $MAKE lib
 #echo "Make return value: $?"
 if  test "$?" != 0 ; then :

--- a/configure.ac
+++ b/configure.ac
@@ -161,7 +161,7 @@ echo "building the szip library...";
 cd ${BASEPBNAME}/szip;
 ./configure --with-pic --enable-shared=no \
     CC="${CC}" CFLAGS="${CFLAGS} ${CPICFLAGS}" CPPFLAGS="${CPPFLAGS}" \
-    AR="${AR}" RANLIB="${RANLIB}
+    AR="${AR}" RANLIB="${RANLIB}"
 $MAKE
 $MAKE install
 SZIP_HOME=`pwd -P`/szip
@@ -175,7 +175,7 @@ cd ../;
     CXX="${CXX}" CXXFLAGS="${CXXFLAGS} ${CXXPICFLAGS}" \
     CC="${CC}" CFLAGS="${CFLAGS} ${CPICFLAGS}" \
     CPPFLAGS="${CPPFLAGS}" LDFLAGS="${LDFLAGS}" \
-    AR="${AR}" RANLIB="${RANLIB}
+    AR="${AR}" RANLIB="${RANLIB}"
 $MAKE lib
 #echo "Make return value: $?"
 AS_IF([ test "$?" != 0 ], 

--- a/configure.ac
+++ b/configure.ac
@@ -24,6 +24,8 @@ CPPFLAGS=`"${R_HOME}/bin/R" CMD config CPPFLAGS`
 F77=`"${R_HOME}/bin/R" CMD config F77`
 MAKE=`"${R_HOME}/bin/R" CMD config MAKE`
 LDFLAGS=`"${R_HOME}/bin/R" CMD config LDFLAGS`
+AR=`"${R_HOME}/bin/R" CMD config AR`
+RANLIB=`"${R_HOME}/bin/R" CMD config RANLIB`
 AC_LANG(C++)
 
 dnl Checks for programs.
@@ -158,7 +160,8 @@ fi;
 echo "building the szip library...";
 cd ${BASEPBNAME}/szip;
 ./configure --with-pic --enable-shared=no \
-    CC="${CC}" CFLAGS="${CFLAGS} ${CPICFLAGS}" CPPFLAGS="${CPPFLAGS}"
+    CC="${CC}" CFLAGS="${CFLAGS} ${CPICFLAGS}" CPPFLAGS="${CPPFLAGS}" \
+    AR="${AR}" RANLIB="${RANLIB}
 $MAKE
 $MAKE install
 SZIP_HOME=`pwd -P`/szip
@@ -171,7 +174,8 @@ cd ../;
     ${WITH_S3_VFD} \
     CXX="${CXX}" CXXFLAGS="${CXXFLAGS} ${CXXPICFLAGS}" \
     CC="${CC}" CFLAGS="${CFLAGS} ${CPICFLAGS}" \
-    CPPFLAGS="${CPPFLAGS}" LDFLAGS="${LDFLAGS}"
+    CPPFLAGS="${CPPFLAGS}" LDFLAGS="${LDFLAGS}" \
+    AR="${AR}" RANLIB="${RANLIB}
 $MAKE lib
 #echo "Make return value: $?"
 AS_IF([ test "$?" != 0 ], 


### PR DESCRIPTION
HI,

Made some small modifications to cover the case where R was built with a compiler that is not in a standard location. The change introduces the variables AR and RANLIB to the configure steps for hdf5 and szip. This should not cause any issues regardless if R was built with LTO or not. Rhdf5lib compiles fine with or without -flto.

As you are probably aware, R 4.1.0 provides flags to control -flto when compiling packages. There is only one small case to cover after all this changes:

If you use --no-use-LTO, -flto is not set when compiling Rhdf5lib. Nevertheless, it is always set when building hdf5 and szip. I am not very sure how R controls this. So if R is built to use LTO, it will always compile hdf5 and szip with -flto. If there is someone using R with LTO support but not enabled unless you specify --use-LTO, szip and hdf5 will not be built with -flto.

Hope this makes sense and covers these edge cases.

Cheers.